### PR TITLE
Fix test running on Windows

### DIFF
--- a/rhdl-core/src/test_module.rs
+++ b/rhdl-core/src/test_module.rs
@@ -343,11 +343,14 @@ impl TestModule {
         cmd.arg("-o")
             .arg(d_path.join("testbench"))
             .arg(d_path.join("testbench.v"));
-        let status = cmd.status()?;
+        let status = cmd
+            .status()
+            .expect("Icarus Verilog should be installed and in your PATH.");
         if !status.success() {
-            bail!("Failed to compile testbench");
+            bail!("Failed to compile testbench with {}", status);
         }
-        let mut cmd = std::process::Command::new(d_path.join("testbench"));
+        let mut cmd = std::process::Command::new("vvp");
+        cmd.arg(d_path.join("testbench"));
         let output = cmd.output()?;
         for case in String::from_utf8_lossy(&output.stdout)
             .lines()

--- a/rhdl-fpga/src/bsp/alchitry/cu/mod.rs
+++ b/rhdl-fpga/src/bsp/alchitry/cu/mod.rs
@@ -30,7 +30,8 @@ pub fn synth_yosys_nextpnr_icepack(v: &ConstrainedVerilog, path: &Path) -> Resul
         .current_dir(path)
         .arg(command_arg)
         .arg("top.v")
-        .output()?;
+        .output()
+        .expect("Yosys should be installed and in your PATH.");
 
     std::fs::write(path.join("yosys.stdout"), &yosys.stdout)?;
     std::fs::write(path.join("yosys.stderr"), &yosys.stderr)?;


### PR DESCRIPTION
Ran into some issues running the standard `cargo test` on Windows, these are just a fix and more verbose error messages so that if other people run into them, the problem is a bit more obvious.

Primarily, it's that the output of iverilog isn't executable on Windows (and really isn't on *nix either, it's just got a shebang in that case) and has to be run with `vvp` as stated in the manpage:
```The output from the iverilog command is not by itself executable on any platform. Instead, the vvp program is invoked to execute the generated output file.```