### PR TITLE
Fix compile of rhdl-bsp on Linux

### DIFF
--- a/rhdl-bsp/src/drivers/mod.rs
+++ b/rhdl-bsp/src/drivers/mod.rs
@@ -1,5 +1,3 @@
-use std::os::macos::raw::stat;
-
 use rhdl::{
     core::{CircuitIO, RHDLError, Timed},
     prelude::{bit_range, sub_trace_type, Digital, ExportError, MountPoint, Path},


### PR DESCRIPTION
Removed an import for "stat" that was MacOS specific and isn't used at all.