### PR TITLE
Fixed adapter HDL descriptor return

### DIFF
--- a/crates/rhdl-core/src/circuit/adapter.rs
+++ b/crates/rhdl-core/src/circuit/adapter.rs
@@ -170,7 +170,7 @@ impl<C: Synchronous, D: Domain> Circuit for Adapter<C, D> {
             endmodule
         };
         Ok(crate::HDLDescriptor {
-            name: child_name.into(),
+            name: name.into(),
             body: module,
             children: [("c".into(), child_hdl)].into(),
         })


### PR DESCRIPTION
small typo fix, when generating a code from a fixture the child of the adapter would be used instead of the adapter itself
Before:
```verilog
module top(input wire [0:0] sysclk, output wire [7:0] rst);
   wire [1:0] inner_input;
   wire [7:0] inner_output;
   assign inner_input[0:0] = sysclk;
   ;
   assign inner_input[1:1] = 1'b0;
   ;
   assign rst = inner_output[7:0];
   ;
   inner_inner inner_inst(.i(inner_input), .o(inner_output));
endmodule
module inner(input wire [1:0] i, output wire [7:0] o);
   inner_inner c(.clock_reset(i[1:0]), .o(o));
endmodule
````
After:
```verilog
module top(input wire [0:0] sysclk, output wire [7:0] rst);
   wire [1:0] inner_input;
   wire [7:0] inner_output;
   assign inner_input[0:0] = sysclk;
   ;
   assign inner_input[1:1] = 1'b0;
   ;
   assign rst = inner_output[7:0];
   ;
   inner inner_inst(.i(inner_input), .o(inner_output));
endmodule
module inner(input wire [1:0] i, output wire [7:0] o);
   inner_inner c(.clock_reset(i[1:0]), .o(o));
endmodule
````